### PR TITLE
feat: Add functions to fetch followers and followed users

### DIFF
--- a/nuxt/managers/userManager.js
+++ b/nuxt/managers/userManager.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { useStores } from "@/stores/counter.js";
 
 let env = import.meta.env.VITE_APP_ENV;
 let url_api;
@@ -32,8 +33,39 @@ async function updateUser(user, token) {
   }
 }
 
+async function getFollowers() {
+  const store = useStores();
+  try {
+    const response = await axios.get(`${url_api}/users/followers/${store.getId()}`, {
+      headers: {
+        Authorization: `Bearer ${store.getToken()}`,
+      },
+    });
+    return response.data.count;
+  } catch (error) {
+    console.error("Error fetching followers:", error);
+  }
+} 
+
+async function getFollowed() {
+  const store = useStores();
+  try {
+    const response = await axios.get(`${url_api}/users/followed/${store.getId()}`, {
+      headers: {
+        Authorization: `Bearer ${store.getToken()}`,
+      },
+    });
+    return response.data.count;
+  } catch (error) {
+    console.error("Error fetching followers:", error);
+  }
+} 
+
+
 const userManager = {
   updateUser,
+  getFollowers,
+  getFollowed,
 };
 
 export default userManager;

--- a/nuxt/pages/perfil.vue
+++ b/nuxt/pages/perfil.vue
@@ -60,6 +60,8 @@
 </template>
 
 <script>
+import axios from 'axios';
+import userManager from '~/managers/userManager';
 import { useStores } from '~/stores/counter';
 
 export default {
@@ -70,8 +72,8 @@ export default {
             User: {
                 nickname: useStores().userInfo.nickname,
                 name: useStores().userInfo.name,
-                followers: 0,
-                followed: 0
+                followers: '',
+                followed: ''
             },
             store: useStores()
         }
@@ -80,10 +82,21 @@ export default {
     methods: {
         setSelectedSection(section) {
             this.selectedSection = section
+        },
+        async getFollowers() {
+            const followers = await userManager.getFollowers();
+            this.User.followers = followers;
+        },
+        async getFollowed() {
+            const followed = await userManager.getFollowed();
+            this.User.followed = followed;
         }
     },
     mounted() {
-        if(!this.store.getLoggedIn()) return this.$router.push('/join');
+        if (!this.store.getLoggedIn()) return this.$router.push('/join');
+        this.getFollowers(); 
+        this.getFollowed();
+
     }
 }
 </script>


### PR DESCRIPTION
The code changes include adding two new functions, `getFollowers()` and `getFollowed()`, to the `userManager` module. These functions make API calls to fetch the count of followers and followed users for a specific user. The functions use the `axios` library and require the user's ID and token for authentication.

This commit message suggests adding the new functions to the `userManager` module to fetch followers and followed users.